### PR TITLE
Use catthehacker/ubuntu as the base image 

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -14,9 +14,10 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    strategy:
+      matrix:
+        release: [jammy, focal, latest]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v3
     -
@@ -39,6 +40,18 @@ jobs:
       shell: bash
       env:
         OWNER: ${{github.repository_owner}}
+    - 
+      name: Replace Docker Image in Dockerfile
+      run: |
+        if [ "${{ matrix.release }}" == "jammy" ]; then
+          version="22.04"
+        elif [ "${{ matrix.release }}" == "focal" ]; then
+          version="20.04"
+        else
+          version="latest"
+        fi
+        sed -i "s/FROM catthehacker\/ubuntu:act-latest.*/FROM catthehacker\/ubuntu:act-${version}-20231008/" Dockerfile
+        sed -i "s/ENV GITEA_RUNNER_LABELS=ubuntu-latest/ENV GITEA_RUNNER_LABELS=ubuntu-${version}/" Dockerfile
     -
       name: Build and push
       uses: docker/build-push-action@v3
@@ -46,4 +59,4 @@ jobs:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: ghcr.io/${{env.LOWNER}}/gitea-actions-runner:${{ inputs.gitea-runner-tag || 'nightly' }},ghcr.io/${{env.LOWNER}}/gitea-actions-runner:${{ inputs.gitea-runner-tag && 'latest' || 'nightly' }}
+        tags: ghcr.io/${{env.LOWNER}}/gitea-actions-runner:ubuntu-${{ matrix.release }}

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -46,6 +46,4 @@ jobs:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
-        build-args: |
-          GITEA_ACTIONS_RUNNER_VERSION=${{ inputs.gitea-runner-tag || 'v0.0.6' }}
-        tags: ghcr.io/${{env.LOWNER}}/gitea-actions-runner:${{ inputs.gitea-runner-tag || 'v0.0.6' }},ghcr.io/${{env.LOWNER}}/gitea-actions-runner:${{ inputs.gitea-runner-tag && 'latest' || 'v0.0.6' }}
+        tags: ghcr.io/${{env.LOWNER}}/gitea-actions-runner:${{ inputs.gitea-runner-tag || 'nightly' }},ghcr.io/${{env.LOWNER}}/gitea-actions-runner:${{ inputs.gitea-runner-tag && 'latest' || 'nightly' }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -35,7 +35,6 @@ jobs:
       #     script: core.setOutput("", ${{ tojson(github.ref)}}.substring("refs/tags/v".length))
 
   container:
-    needs: goreleaser
     if: startsWith(github.ref, 'refs/tags/')
     uses: ./.github/workflows/build_container.yml
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,17 +26,6 @@ RUN curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-c
     && unzip ./runner-container-hooks.zip -d ./k8s \
     && rm runner-container-hooks.zip
 
-RUN export RUNNER_ARCH=${TARGETARCH} \
-    && if [ "$RUNNER_ARCH" = "amd64" ]; then export DOCKER_ARCH=x86_64 ; fi \
-    && if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
-    && curl -fLo docker.tgz https://download.docker.com/${TARGETOS}/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
-    && tar zxvf docker.tgz \
-    && rm -rf docker.tgz \
-    && mkdir -p /usr/local/lib/docker/cli-plugins \
-    && curl -fLo /usr/local/lib/docker/cli-plugins/docker-buildx \
-        "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TARGETARCH}" \
-    && chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
-
 FROM golang:1.21-alpine3.18 as builder
 # Do not remove `git` here, it is required for getting runner version when executing `make build`
 RUN apk add --no-cache make git
@@ -46,29 +35,19 @@ WORKDIR /opt/src/act_runner
 
 RUN make clean && make build
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-jammy
+FROM catthehacker/ubuntu:act-latest-20231008
 
-ENV DEBIAN_FRONTEND=noninteractive
+ENV GITEA_RUNNER_LABELS=ubuntu-latest
 ENV RUNNER_MANUALLY_TRAP_SIG=1
 ENV ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1
-ENV ImageOS=ubuntu22
 ENV ACTIONS_RUNNER_CONTAINER_HOOKS=/home/runner/docker-hooks/index.js
 
-RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends \
-    sudo \
-    jq \
-    curl \
-    git \
-    lsb-release \
-    && rm -rf /var/lib/apt/lists/*
-
 RUN adduser --disabled-password --gecos "" --uid 1000 runner \
-    && groupadd docker --gid 123 \
     && usermod -aG sudo runner \
     && usermod -aG docker runner \
     && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers \
-    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers \
+    && echo "root ALL=(ALL) ALL" >> /etc/sudoers
 
 WORKDIR /home/runner
 
@@ -76,9 +55,6 @@ VOLUME /home/runner/externals
 VOLUME /home/runner/_work
 
 COPY --chown=runner:docker --from=build /actions-runner .
-COPY --from=build /usr/local/lib/docker/cli-plugins/docker-buildx /usr/local/lib/docker/cli-plugins/docker-buildx
-
-RUN install -o root -g root -m 755 docker/* /usr/bin/ && rm -rf docker
 
 RUN mkdir -p /runner && chown runner:docker -R /runner && ln -s /data/.actions_runner .runner
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DIST := dist
-EXECUTABLE := act_runner
+EXECUTABLE := gitea-actions-runner
 GOFMT ?= gofumpt -l
 DIST := dist
 DIST_DIRS := $(DIST)/binaries $(DIST)/release

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Actions runner is a runner for Gitea based on [actions/runner](https://github.co
 - Download and extract actions/runner https://github.com/actions/runner/releases
 - You have to create simple .runner file in the root folder of the actions/runner with the following Content
   ```
-  {"workFolder": "_work"}
+  {"isHostedServer": false, "agentName": "my-runner", "workFolder": "_work"}
   ```
 
 ## Quickstart

--- a/examples/docker-compose-dind/docker-compose.yml
+++ b/examples/docker-compose-dind/docker-compose.yml
@@ -1,4 +1,4 @@
-# docker-compose.yml 
+# docker-compose.yml
 networks:
   runner:
     external: false
@@ -9,39 +9,33 @@ volumes:
     driver: local
   gitea-runner-data:
     driver: local
-  docker-certs:
+  socket:
     driver: local
 services:
   runner:
-    image: ghcr.io/christopherhx/gitea-actions-runner:latest
+    image: ghcr.io/christopherhx/gitea-actions-runner:ubuntu-focal
     environment:
-      - GITEA_INSTANCE_URL=https://gitea.com                            # Your Gitea Instance to register to
-      - GITEA_RUNNER_REGISTRATION_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX # The Gitea registration token
-      - GITEA_RUNNER_LABELS=self-hosted                                 # The labels of your runner (comma separated)
-      - DOCKER_TLS_CERTDIR=/certs                                       # DIND
-      - DOCKER_CERT_PATH=/certs/client                                  # DIND
-      - DOCKER_TLS_VERIFY=1                                             # DIND
-      - DOCKER_HOST=tcp://docker:2376                                   # DIND
+      - GITEA_INSTANCE_URL=https://gitea.com/                            # Your Gitea Instance to register to
+      - GITEA_RUNNER_REGISTRATION_TOKEN=XXXXXXXXXXXXXXXXXXXXXXX          # The Gitea registration token
+      - GITEA_RUNNER_LABELS=self-hosted                                  # The labels of your runner (comma separated)
     restart: always
+    user: root
     networks:
       - runner
     volumes:
       - gitea-runner-data:/data                 # Persist runner registration across updates
       - runner:/home/runner/_work               # DIND
       - runner-externals:/home/runner/externals # DIND
-      - docker-certs:/certs                     # DIND
+      - socket:/var/run
     depends_on:
       - docker
   docker:
-    image: docker:dind-rootless
+    image: docker:dind
     restart: always
     privileged: true
-    environment:
-      - DOCKER_TLS_CERTDIR=/certs
     networks:
       - runner
     volumes:
       - runner:/home/runner/_work
       - runner-externals:/home/runner/externals
-      - docker-certs:/certs
-      - ./var-lib-docker:/var/lib/docker
+      - socket:/var/run

--- a/start.sh
+++ b/start.sh
@@ -51,7 +51,7 @@ if [[ ! -s "$RUNNER_STATE_FILE" ]]; then
       jq --null-input \
          --arg agentName "${GITEA_RUNNER_NAME:-`hostname`}" \
          --arg workFolder "/home/runner/_work" \
-        '{ "agentName": $agentName, "workFolder": $workFolder }' > /data/.actions_runner
+        '{ "isHostedServer": false, "agentName": $agentName, "workFolder": $workFolder }' > /data/.actions_runner
     else
       echo "Waiting to retry ..."
       try=$(($try + 1))


### PR DESCRIPTION
chore: Use catthehacker/ubuntu as the base image 

ℹ️ This commit updates the Dockerfile to use catthehacker/ubuntu as the base image. This choice was made due to [provide brief reasons for choosing this base image].  

🔄 Changes Made: - Updated Dockerfile to use catthehacker/ubuntu as the base image.