### PR TITLE
Minor improvement

### DIFF
--- a/actions/server/server.go
+++ b/actions/server/server.go
@@ -94,7 +94,7 @@ func (server *ActionsServer) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 	}
 	jsonResponse := func(data interface{}) {
 		resp.Header().Add("content-type", "application/json")
-		resp.WriteHeader(200)
+		resp.WriteHeader(http.StatusOK)
 		json, _ := json.Marshal(data)
 		resp.Write(json)
 	}
@@ -118,16 +118,16 @@ func (server *ActionsServer) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 	} else if strings.HasPrefix(req.URL.Path, "/_apis/v1/FinishJob") {
 		recs := &protocol.JobEvent{}
 		jsonRequest(recs)
-		resp.WriteHeader(200)
+		resp.WriteHeader(http.StatusOK)
 	} else if strings.HasPrefix(req.URL.Path, "/_apis/v1/TimeLineWebConsoleLog/") {
 		recs := &protocol.TimelineRecordFeedLinesWrapper{}
 		jsonRequest(recs)
-		resp.WriteHeader(200)
+		resp.WriteHeader(http.StatusOK)
 	} else if strings.HasPrefix(req.URL.Path, "/_apis/v1/Logfiles") {
 		logPath := "/_apis/v1/Logfiles/"
 		if strings.HasPrefix(req.URL.Path, logPath) && len(logPath) < len(req.URL.Path) {
 			io.Copy(io.Discard, req.Body)
-			resp.WriteHeader(200)
+			resp.WriteHeader(http.StatusOK)
 		} else {
 			p := "logs\\0.log"
 			recs := &protocol.TaskLog{
@@ -223,14 +223,14 @@ func (server *ActionsServer) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 	} else if strings.HasPrefix(req.URL.Path, "/_apis/v1/ActionDownload") {
 		req, err := http.NewRequestWithContext(req.Context(), "GET", req.URL.Query().Get("url"), nil)
 		if err != nil {
-			resp.WriteHeader(404)
+			resp.WriteHeader(http.StatusNotFound)
 			return
 		}
 		req.Header.Add("User-Agent", "github-act-runner/1.0.0")
 		req.Header.Add("Accept", "*/*")
 		rsp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			resp.WriteHeader(404)
+			resp.WriteHeader(http.StatusNotFound)
 			return
 		}
 		defer rsp.Body.Close()
@@ -245,7 +245,7 @@ func (server *ActionsServer) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 		defer req.Body.Close()
 		myreq, err := http.NewRequestWithContext(req.Context(), req.Method, url.String(), req.Body)
 		if err != nil {
-			resp.WriteHeader(404)
+			resp.WriteHeader(http.StatusNotFound)
 			return
 		}
 		for k, vs := range req.Header {
@@ -253,7 +253,7 @@ func (server *ActionsServer) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 		}
 		rsp, err := http.DefaultClient.Do(myreq)
 		if err != nil {
-			resp.WriteHeader(404)
+			resp.WriteHeader(http.StatusNotFound)
 			return
 		}
 		defer rsp.Body.Close()
@@ -264,7 +264,7 @@ func (server *ActionsServer) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 		resp.WriteHeader(rsp.StatusCode)
 		io.Copy(resp, rsp.Body)
 	} else if strings.HasPrefix(req.URL.Path, "/_apis/v1/ActionDownload") {
-		resp.WriteHeader(404)
+		resp.WriteHeader(http.StatusNotFound)
 	} else if strings.HasPrefix(req.URL.Path, "/JobRequest") {
 		SYSTEMVSSCONNECTION := req.URL.Query().Get("SYSTEMVSSCONNECTION")
 		// Normalize the URL to ensure it ends with a slash
@@ -289,7 +289,7 @@ func (server *ActionsServer) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 				}
 			}
 		}
-		resp.WriteHeader(200)
+		resp.WriteHeader(http.StatusOK)
 		resp.Header().Add("content-type", "application/json")
 		resp.Header().Add("accept", "application/json")
 		src, _ := json.Marshal(server.JobRequest)
@@ -297,7 +297,7 @@ func (server *ActionsServer) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 	} else if strings.HasPrefix(req.URL.Path, "/WaitForCancellation") {
 		resp.Header().Add("content-type", "application/json")
 		resp.Header().Add("accept", "application/json")
-		resp.WriteHeader(200)
+		resp.WriteHeader(http.StatusOK)
 		resp.(http.Flusher).Flush()
 		for {
 			select {
@@ -317,6 +317,6 @@ func (server *ActionsServer) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 	} else if server.CacheHandler != nil {
 		server.CacheHandler.ServeHTTP(resp, req)
 	} else {
-		resp.WriteHeader(404)
+		resp.WriteHeader(http.StatusNotFound)
 	}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.1.5"
+var version = "local"
 
 type globalArgs struct {
 	EnvFile string

--- a/register/register.go
+++ b/register/register.go
@@ -65,5 +65,5 @@ func (p *Register) Register(ctx context.Context, cfg config.Runner) (*core.Runne
 	}
 
 	// store runner config in .runner file
-	return data, os.WriteFile(cfg.File, file, 0o644)
+	return data, os.WriteFile(cfg.File, file, 0o640)
 }

--- a/runtime/task.go
+++ b/runtime/task.go
@@ -343,14 +343,14 @@ func (t *Task) Run(ctx context.Context, task *runnerv1.Task, runnerWorker []stri
 	} else {
 		shouldskip = true
 	}
-	aserver := &server.ActionsServer{
+	actionsHttpServerHandler := &server.ActionsServer{
 		TraceLog:         make(chan interface{}),
 		ServerURL:        dataContext["server_url"].GetStringValue(),
 		ActionsServerURL: dataContext["gitea_default_actions_url"].GetStringValue(),
 		AuthData:         map[string]*protocol.ActionDownloadAuthentication{},
 	}
 	defer func() {
-		close(aserver.TraceLog)
+		close(actionsHttpServerHandler.TraceLog)
 	}()
 	steps := []protocol.ActionStep{}
 	type StepMeta struct {
@@ -395,7 +395,7 @@ func (t *Task) Run(ctx context.Context, task *runnerv1.Task, runnerWorker []stri
 				nextLogSync = time.Until(rows[0].Time.AsTime().Add(time.Second))
 			}
 			select {
-			case obj, ok = <-aserver.TraceLog:
+			case obj, ok = <-actionsHttpServerHandler.TraceLog:
 			case <-time.After(nextLogSync):
 				if taskStateChanged && updateTask(reportingCtx, t, taskState, cancel, nil) == nil {
 					taskStateChanged = false
@@ -591,14 +591,14 @@ func (t *Task) Run(ctx context.Context, task *runnerv1.Task, runnerWorker []stri
 	}
 	_, workerV2 := workerOptions["--worker-v2"]
 
-	var httpServer *http.Server
+	var actionsHttpServer *http.Server
 	if !workerV2 {
-		httpServer = &http.Server{Handler: aserver}
+		actionsHttpServer = &http.Server{Handler: actionsHttpServerHandler}
 	}
 
 	defer func() {
-		if httpServer != nil {
-			httpServer.Shutdown(context.Background())
+		if actionsHttpServer != nil {
+			actionsHttpServer.Shutdown(context.Background())
 		}
 		message := "Finished"
 		log.Info(message)
@@ -676,10 +676,10 @@ func (t *Task) Run(ctx context.Context, task *runnerv1.Task, runnerWorker []stri
 		externalURL = fmt.Sprintf("http://%s:%d/", hostname, listener.Addr().(*net.TCPAddr).Port)
 	}
 	// Normalize externalURL to ensure it ends with a slash
-	aserver.ExternalURL = strings.TrimSuffix(externalURL, "/") + "/"
+	actionsHttpServerHandler.ExternalURL = strings.TrimSuffix(externalURL, "/") + "/"
 
 	cacheServerUrl := os.Getenv("GITEA_ACTIONS_CACHE_SERVER_URL")
-	if httpServer != nil && cacheServerUrl == "" {
+	if actionsHttpServer != nil && cacheServerUrl == "" {
 		if wd, err := os.Getwd(); err == nil {
 			if actionsRuntimeListeningAddr == ":0" {
 				if cache, err := artifactcache.StartHandler(filepath.Join(wd, "cache"), hostname, 0, log.New()); err == nil {
@@ -687,7 +687,7 @@ func (t *Task) Run(ctx context.Context, task *runnerv1.Task, runnerWorker []stri
 					defer cache.Close()
 				}
 			} else {
-				_, aserver.CacheHandler, _ = artifactcache.CreateHandler(filepath.Join(wd, "cache"), externalURL, nil)
+				_, actionsHttpServerHandler.CacheHandler, _ = artifactcache.CreateHandler(filepath.Join(wd, "cache"), externalURL, nil)
 				cacheServerUrl = externalURL
 			}
 		}
@@ -696,9 +696,9 @@ func (t *Task) Run(ctx context.Context, task *runnerv1.Task, runnerWorker []stri
 	if cacheServerUrl != "" {
 		cacheServerUrl = strings.TrimSuffix(cacheServerUrl, "/") + "/"
 	}
-	if httpServer != nil {
+	if actionsHttpServer != nil {
 		go func() {
-			httpServer.Serve(listener)
+			actionsHttpServer.Serve(listener)
 		}()
 	}
 
@@ -759,7 +759,7 @@ func (t *Task) Run(ctx context.Context, task *runnerv1.Task, runnerWorker []stri
 						re := strings.Split(strings.TrimPrefix(nameAndPathOrRef[0], proto), "/")
 						nameAndPath = append([]string{strings.ReplaceAll(proto+re[0]+"/"+re[1], ":", "~")}, re[2:]...)
 						if token != "" {
-							aserver.AuthData[nameAndPathOrRef[0]] = &protocol.ActionDownloadAuthentication{
+							actionsHttpServerHandler.AuthData[nameAndPathOrRef[0]] = &protocol.ActionDownloadAuthentication{
 								Token: token,
 							}
 						}
@@ -1018,8 +1018,8 @@ func (t *Task) Run(ctx context.Context, task *runnerv1.Task, runnerWorker []stri
 		jmessage.Variables[k] = protocol.VariableValue{Value: v, IsSecret: true}
 	}
 
-	aserver.JobRequest = jmessage
-	aserver.CancelCtx = ctx
+	actionsHttpServerHandler.JobRequest = jmessage
+	actionsHttpServerHandler.CancelCtx = ctx
 	src, _ := json.Marshal(jmessage)
 	jobExecCtx := ctx
 
@@ -1053,7 +1053,7 @@ func (t *Task) Run(ctx context.Context, task *runnerv1.Task, runnerWorker []stri
 	var workerLog *bytes.Buffer
 	if workerV2 {
 		go func() {
-			server.Server(server.CreateStdioConn(out, in), aserver)
+			server.Server(server.CreateStdioConn(out, in), actionsHttpServerHandler)
 		}()
 	} else {
 		mid := make([]byte, 4)


### PR DESCRIPTION
Not a big deal, yet still want to propose these changes.
- Writing HTTP status code use existing constants.
- `cmd.version` `0.1.5` seems not that indicative (and misleading). Fall to a "local" value instead. `make` already takes care of the value while building.
- Lower `.runner` file permission to 640, instead of 644.
- Rename some variables in `task.go` for readability.